### PR TITLE
Restructured code to support exclusive content

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Add the below divs just above the `id="monetization-exclusive"` area. This will 
     This content is exclusive to my supporters.
   </p>
   <p>
-    Please install a <a href="https://chrome.google.com/webstore/detail/coil/locbifcbeldmnphbgkdigjmkbfkhbnca?hl=en" target="_blank">Web Monetization extension</a> to support me!
+    Please install a Web Monetization provider extension to support me!
   </p>
 </div>
 

--- a/dist/monet.js
+++ b/dist/monet.js
@@ -13,9 +13,7 @@ function showLoading () {
     document.getElementById('monetization-loading').classList.remove('monetization--hidden')
 }
 
-const isWebMonetizationSupported = document.createElement('link').relList.supports('monetization');
-
-if (isWebMonetizationSupported) {
+function addMonetizationEventListener() {
     const link = document.querySelector('link[rel="monetization"]')
     link.addEventListener('monetization', () => {
         showExclusiveContent()
@@ -23,9 +21,11 @@ if (isWebMonetizationSupported) {
 }
 
 window.addEventListener('load', () => {
-    if (!document.monetization) {
+    const isWebMonetizationSupported = document.createElement('link').relList.supports('monetization');
+    if (!isWebMonetizationSupported) {
         showCTA()
     } else {
         showLoading()
+        addMonetizationEventListener()
     }
 })


### PR DESCRIPTION
The `link` rellist doesn't support 'monetization'  by default at least until there is browser support. it is added by the web monetization provider instead. ` const isWebMonetizationSupported = document.createElement('link').relList.supports('monetization');` will return false if it is outside window load event. Hence this restructure is needed.

On another note, I would love to see this on `npm` after my changes are merged. Can you please publish this @DanCanetti . If you no longer wish to maintain this then please let me know, I would love to maintain and publish this as a Web monetization enthusiast and an Interledger Ambassador.